### PR TITLE
Overrule smart battery management

### DIFF
--- a/lib/plenticore.js
+++ b/lib/plenticore.js
@@ -25,6 +25,7 @@ let hasBattery = false;
 let panelWp = 0;
 let maxFeedInPower = 5000;
 let batteryStrategy = '1';
+let batteryStrategyMode = '1';
 
 let consumptionData = {};
 let generationData = {};
@@ -659,6 +660,7 @@ function setup(callback) {
 	panelWp = getPanelWp();
 	maxFeedInPower = getMaxFeedInPower();
 	batteryStrategy = getBatteryStrategy();
+	batteryStrategyMode = getBatteryStrategyMode();
 
 	adapter.log.info('Configured Wp of panel(s) is ' + Math.round(panelWp));
 	adapter.log.info('Configured maximum feed-in power is ' + maxFeedInPower);
@@ -842,6 +844,17 @@ function getBatteryStrategy() {
 	let strategy = adapter.config.battery_strategy;
 
 	return strategy;
+}
+
+function getBatteryStrategyMode() {
+	let strategyMode = 1;
+
+	adapter.getState('devices.local.battery.SmartBatteryControlMode', function(err, state) {
+		if(!err && state) {
+			strategyMode = state.val;
+		}
+	});
+	return strategyMode;
 }
 
 
@@ -2379,6 +2392,7 @@ function calcMinSoC(forecastRead, tomorrow) {
 
 		// Decide if the Kostal smart battery management should be switched on or off
 		if(adapter.config.enable_battery_management) {
+			// automatic selection should be used
 			let daily_cons = 0;
 			let curSoC = 0;
 			let curSoCPercentage = 0;
@@ -2409,7 +2423,8 @@ function calcMinSoC(forecastRead, tomorrow) {
 						adapter.log.info('Calculated remaining energy: ' + power_plus + ' (power_plus = powerUntilSunset - daily_cons + curSoC - adapter.config.battery_capacity)');
 
 						// Switch smart battery control; depending on the battery strategy selected in the adapter settings
-						if (batteryStrategy == '2') {
+						if ( (batteryStrategyMode == 1) && (batteryStrategy == '2') ) {
+							// Only if automated mode is not overruled
 							// Do not change smart setting in last 1/4 between sunrise and sunset. Otherwise we would switch off at the end of each day when power_plus gets to 0. The Kostal-SmartBatteryControl works better if it is not switched on/off too often.
 							if ( (timeNow.getTime() < (sunset.getTime() - 0.25 * (sunset.getTime() - sunrise.getTime()))) && (timeNow > sunrise) ) {
 								// if the forecast does not see a risk of exceeding the limit: switch off
@@ -2437,7 +2452,8 @@ function calcMinSoC(forecastRead, tomorrow) {
 									}
 								}
 							}
-						} else {
+						} else if (batteryStrategyMode == 1) {
+							// Only if automated mode is not overruled
 							// Strategy_1
 							if(parseInt(curSoCPercentage) < parseInt(curMinSoC) + 8) {
 								adapter.log.info('Strategy #1: Disabling battery management because ' + curMinSoC + ' is too high for current SoC ' + curSoCPercentage);
@@ -3051,6 +3067,23 @@ function changeSetting(id, value) {
 	let moduleid;
 	let settingid;
 
+	// check first the special cases which should be transferred to the plenticore decive
+	if (id == 'devices.local.battery.SmartBatteryControlMode') {
+		// Setting to overrule the automatic setting of smart battery management
+		adapter.log.info('Changed ' + id + ' with to value ' + value);
+
+		batteryStrategyMode = value;
+
+		if (batteryStrategyMode == 2) {
+			setSmartBatteryControl(false);
+		} else if (batteryStrategyMode == 3) {
+			setSmartBatteryControl(true);
+		}
+		
+		return;
+	}
+	
+	// now all cases to the plenticore device
 	for(let i = 0; i < payload_settings.length; i++) {
 		for(let idx in payload_settings[i].mappings) {
 			if(payload_settings[i].mappings[idx].id === id) {
@@ -4295,6 +4328,24 @@ function setObjects() {
 			role: 'switch.enable',
 			read: true,
 			write: true
+		},
+		native: {}
+	});
+
+	adapter.setObjectNotExists('devices.local.battery.SmartBatteryControlMode', {
+		type: 'state',
+		common: {
+			name: 'Smart battery control mode (overrule)',
+			type: 'number',
+			role: 'level',
+			read: true,
+			write: true,
+			states: {
+				1: 'auto',
+				2: 'off',
+				3: 'on'
+			},
+			def: 1
 		},
 		native: {}
 	});

--- a/lib/plenticore.js
+++ b/lib/plenticore.js
@@ -4341,9 +4341,9 @@ function setObjects() {
 			read: true,
 			write: true,
 			states: {
-				1: 'smart mgmt: automatic decision (Adapter strategy decides if Kostal decides)',
-				2: 'smart mgmt: off (load battery)',
-				3: 'smart mgmt: on (Kostal SW decides)'
+				1: 'auto decision',
+				2: 'off (load battery)',
+				3: 'on (Kostal smart)'
 			},
 			def: 1,
 			desc: {

--- a/lib/plenticore.js
+++ b/lib/plenticore.js
@@ -4341,11 +4341,24 @@ function setObjects() {
 			read: true,
 			write: true,
 			states: {
-				1: 'auto',
-				2: 'off',
-				3: 'on'
+				1: 'smart mgmt: automatic decision (Adapter strategy decides if Kostal decides)',
+				2: 'smart mgmt: off (load battery)',
+				3: 'smart mgmt: on (Kostal SW decides)'
 			},
-			def: 1
+			def: 1,
+			desc: {
+				en: 'off: smart battery management is always off, so that battery is loaded  --- on: smart battery management is always on, so that the Kostal SW decides --- automatic decision: the strategy of this adapter decided if the smart battery management is switched on or off.',
+				de: 'aus: Die intelligente Batterieverwaltung ist immer ausgeschaltet, damit der Akku geladen wird --- ein: Die intelligente Batterieverwaltung ist immer eingeschaltet, damit die Kostal SW entscheidet --- automatische Entscheidung: Die Strategie dieses Adapters entscheidet, ob die intelligente Batterieverwaltung ein- oder ausgeschaltet ist.',
+				ru: 'выкл: умное управление батареей всегда отключено, чтобы батарея была заряжена --- вкл: умное управление батареей всегда включено, чтобы Kostal SW решал --- автоматическое решение: стратегия этого адаптера определяет, включено или выключено умное управление батареей.',
+				pt: 'desligado: o gerenciamento inteligente da bateria está sempre desligado, para que a bateria seja carregada --- ligado: o gerenciamento inteligente da bateria está sempre ligado, para que o Kostal SW decida --- decisão automática: a estratégia deste adaptador decide se o gerenciamento inteligente da bateria está ligado ou desligado.',
+				nl: 'uit: slim batterijbeheer staat altijd uit, zodat de batterij wordt geladen --- aan: slim batterijbeheer staat altijd aan, zodat de Kostal SW beslist --- automatische beslissing: de strategie van deze adapter beslist of het slim batterijbeheer is in- of uitgeschakeld.',
+				fr: 'off : la gestion intelligente de la batterie est toujours désactivée, de sorte que la batterie soit chargée --- on : la gestion intelligente de la batterie est toujours activée, de sorte que Kostal SW décide --- décision automatique : la stratégie de cet adaptateur décide si la gestion intelligente de la batterie est activée ou désactivée.',
+				it: 'off: la gestione intelligente della batteria è sempre disattivata, in modo che la batteria sia caricata --- on: la gestione intelligente della batteria è sempre attivata, in modo che Kostal SW decida --- decisione automatica: la strategia di questo adattatore decide se la gestione intelligente della batteria è attivata o disattivata.',
+				es: 'off: la gestión inteligente de la batería siempre está apagada, para que la batería se cargue --- on: la gestión inteligente de la batería siempre está encendida, para que el Kostal SW decida --- decisión automática: la estrategia de este adaptador decide si la gestión inteligente de la batería está encendida o apagada.',
+				pl: 'wyłączony: inteligentne zarządzanie baterią jest zawsze wyłączone, aby bateria była ładowana --- włączony: inteligentne zarządzanie baterią jest zawsze włączone, aby Kostal SW podejmował decyzje --- decyzja automatyczna: strategia tego adaptera decyduje, czy inteligentne zarządzanie baterią jest włączone lub wyłączone.',
+				'zh-cn': '关闭：智能电池管理始终关闭，以便电池加载---打开：智能电池管理始终打开，以便Kostal SW决策---自动决策：该适配器的策略决定启用或禁用智能电池管理。',
+				uk: 'Вимкнено: розумне керування батареєю завжди вимкнено, щоб батарея завантажувалась --- Увімкнено: розумне керування батареєю завжди увімкнено, щоб рішення Kostal SW приймало --- Автоматичне рішення: стратегія цього адаптера вирішує, чи вмикається розумне керування батареєю, чи вимикається.'
+			}			
 		},
 		native: {}
 	});


### PR DESCRIPTION
I recognized that labels of the values were inituitive. 
Hopefully it is better now. Also a description was added (incl. translations).

To see new values, delete "plenticore.0.devices.local.battery.SmartBatteryControlMode" and restart the adapter.