### PR TITLE
Update plenticore.js

### DIFF
--- a/lib/plenticore.js
+++ b/lib/plenticore.js
@@ -4353,7 +4353,7 @@ function setObjects() {
 			read: true,
 			write: true,
 			min: 0,
-			max: 10000,
+			max: 38000,
 			unit: 'W'
 		},
 		native: {}


### PR DESCRIPTION
Höchstmöglicher Wert auf 38000 geändert. Das ist der höchste Wert den man im Wechselrichter eintragen kann.